### PR TITLE
Hide cursor when prompting for Confirm

### DIFF
--- a/lib/inquirer/prompts/confirm.rb
+++ b/lib/inquirer/prompts/confirm.rb
@@ -77,23 +77,25 @@ class Confirm
     IOHelper.render( update_prompt )
     # loop through user confirm
     # IOHelper.read_char
-    IOHelper.read_key_while true do |key|
-      raw  = IOHelper.char_to_raw(key)
+    IOHelper.without_cursor do
+      IOHelper.read_key_while true do |key|
+        raw  = IOHelper.char_to_raw(key)
 
-      case raw
-      when "y","Y"
-        @value = true
-        false
-      when "n","N"
-        @value = false
-        false
-      when "return"
-        @value = @default
-        false
-      else
-        true
+        case raw
+        when "y","Y"
+          @value = true
+          false
+        when "n","N"
+          @value = false
+          false
+        when "return"
+          @value = @default
+          false
+        else
+          true
+        end
+
       end
-
     end
 
     # clear the final prompt and the line


### PR DESCRIPTION
To me at least, showing the cursor with a Confirm prompt just makes it look messy...
We're not printing out the character that's provided anyway, which seems to be implied by the presence of the cursor.
