### PR TITLE
Add Ctrl module to handle some shell hotkeys

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "rake/testtask"
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.pattern = "test/classes/*_spec.rb"
+  t.pattern = "test/{classes,utils}/*_spec.rb"
   t.verbose = true
 end
 

--- a/lib/inquirer.rb
+++ b/lib/inquirer.rb
@@ -1,5 +1,6 @@
 require 'inquirer/version'
 require 'inquirer/utils/iohelper'
+require 'inquirer/utils/ctrl'
 require 'inquirer/prompts/list'
 require 'inquirer/prompts/checkbox'
 require 'inquirer/prompts/input'

--- a/lib/inquirer/prompts/input.rb
+++ b/lib/inquirer/prompts/input.rb
@@ -44,6 +44,7 @@ class InputResponseDefault
 end
 
 class Input
+  include Ctrl
   def initialize question = nil, default = nil, renderer = nil, responseRenderer = nil
     @question = question
     @value = ""
@@ -99,6 +100,14 @@ class Input
           @pos = @pos - 1
           print IOHelper.char_right
         end
+      when /^ctrl-([aekuw])$/
+        ctrl $1.to_sym
+        IOHelper.rerender( update_prompt )
+        update_cursor
+      when /^alt-([bdf])$/
+        alt $1.to_sym
+        IOHelper.rerender( update_prompt )
+        update_cursor
       when "return"
         if not @default.nil? and @value == ""
           @value = @default

--- a/lib/inquirer/utils/ctrl.rb
+++ b/lib/inquirer/utils/ctrl.rb
@@ -1,0 +1,48 @@
+module Ctrl
+  def ctrl(key)
+    case key
+    when :a
+      @pos = @value.length
+    when :e
+      @pos = 0
+    when :k
+      # delete to end of line
+      @value = @value[0...@value.length-@pos]
+      @pos = 0
+    when :u
+      # delete to beginning of line
+      @value = @value[@value.length - @pos...@value.length]
+      @pos = @value.length
+    when :w
+      # delete word before cursor
+      head = @value[0...@value.length-@pos].rstrip
+      tail = @value[@value.length - @pos...@value.length]
+      head[-1] = '' while head[-1] != ' ' and head[-1]
+      @value = head + tail
+    end # case key
+  end # def ctrl(key)
+
+  def alt(key)
+    case key
+    when :d
+      # delete word after cursor
+      head = @value[0...@value.length-@pos]
+      tail = @value[@value.length - @pos...@value.length].lstrip
+      tail[0] = '' while tail[0] != ' ' and tail[0]
+      @pos = tail.length
+      @value = head + tail
+    when :f
+      # jump to end of word
+      @pos -= 1 while @pos != 0 and @value[@value.length-@pos] == ' '
+      @pos -= 1 while @pos != 0 and @value[@value.length-@pos] != ' '
+    when :b
+      # jump to beginning of word
+      while @pos < @value.length and [nil, ' '].include? @value[@value.length-(@pos+1)]
+        @pos += 1
+      end
+      while @pos < @value.length and @value[@value.length-(@pos+1)] != ' '
+        @pos += 1
+      end
+    end # case key
+  end # def alt(key)
+end

--- a/lib/inquirer/utils/iohelper.rb
+++ b/lib/inquirer/utils/iohelper.rb
@@ -16,10 +16,26 @@ module IOHelper
     "\e[C" => "right",
     "\e[D" => "left",
     "\177" => "backspace",
-    # ctrl + c
+    # ctrl + c    cancel
     "\003" => "ctrl-c",
-    # ctrl + d
-    "\004" => "ctrl-d"
+    # ctrl + d    exit
+    "\004" => "ctrl-d",
+    # ctrl + w    delete word before cursor
+    "\u0017" => "ctrl-w",
+    # alt  + d    delete word after cursor
+    "\ed" => "alt-d",
+    # alt  + b    jump to beginning of word
+    "\eb" => "alt-b",
+    # alt  + f    jump to end of word
+    "\ef" => "alt-f",
+    # ctrl + a    jump to beginning of line
+    "\u0001" => "ctrl-a",
+    # ctrl + e    jump to end of line
+    "\u0005" => "ctrl-e",
+    # ctrl + u    delete to beginning of line
+    "\u0015" => "ctrl-u",
+    # ctrl + k    delete to end of line
+    "\v" => "ctrl-k"
   }
 
   # Read a character the user enters on console. This call is synchronous blocking.

--- a/test/utils/ctrl_spec.rb
+++ b/test/utils/ctrl_spec.rb
@@ -1,0 +1,116 @@
+require 'minitest_helper'
+
+TEST_STRING="  foo   bar baz  "
+
+describe Ctrl do
+  include Ctrl
+  before :each do
+    @value = TEST_STRING
+    @pos = 0
+  end
+
+  describe "#ctrl" do
+    describe :w do
+      it "should delete to the beginning of the word before @pos" do
+        ctrl :w
+        @value.must_equal "  foo   bar "
+        ctrl :w
+        @value.must_equal "  foo   "
+        ctrl :w
+        @value.must_equal "  "
+        ctrl :w
+        @value.must_equal ""
+      end
+
+      it "won't delete anything if there's nothing in front of it" do
+        @pos = @value.length
+        ctrl :w
+        @value.must_equal TEST_STRING
+      end
+    end # describe :w do
+    describe :k do
+      it "should delete to the end of the line after @pos" do
+        @pos = 5
+        ctrl :k
+        @value.must_equal "  foo   bar "
+        @pos = @value.length
+        ctrl :k
+        @value.must_equal ""
+      end
+    end # describe :k do
+    describe :u do
+      it "should delete to the beginning of the line before @pos" do
+        @pos = 12
+        ctrl :u
+        @value.must_equal "   bar baz  "
+        @pos = 0
+        ctrl :u
+        @value.must_equal ""
+      end
+    end # describe :u do
+  end # describe "#ctrl" do
+  describe "#alt" do
+    describe :d do
+      it "will delete to the end of the word after @pos" do
+        @pos = @value.length
+        alt :d
+        @value.must_equal "   bar baz  "
+        @pos.must_equal @value.length
+        alt :d
+        @value.must_equal " baz  "
+        @pos.must_equal @value.length
+        alt :d
+        @value.must_equal "  "
+        @pos.must_equal @value.length
+        alt :d
+        @value.must_equal ""
+        @pos.must_equal @value.length
+      end
+
+      it "will update the position" do
+        @pos = @value.length
+        alt :d
+        @pos.must_equal @value.length
+        @pos = 5
+        alt :d
+        @pos.must_equal 2
+        alt :d
+        @pos.must_equal 0
+      end
+
+      it "won't delete anything if there's nothing after it" do
+        alt :d
+        @value.must_equal TEST_STRING
+      end
+    end # describe :d do
+
+    describe :f do
+      it "jumps to the end of the word" do
+        @pos = @value.length
+        alt :f
+        @pos.must_equal 12
+        alt :f
+        @pos.must_equal 6
+        alt :f
+        @pos.must_equal 2
+        alt :f
+        @pos.must_equal 0
+        alt :f
+        @pos.must_equal 0
+      end
+    end # describe :f do
+    describe :b do
+      it "jumps to the beginning of the word" do
+        alt :b
+        @pos.must_equal 5
+        alt :b
+        @pos.must_equal 9
+        alt :b
+        @pos.must_equal 15
+        alt :b
+        @pos.must_equal 17
+        alt :b
+      end
+    end
+  end # describe "#alt" do
+end


### PR DESCRIPTION
Added support for the following shortcuts:
ctrl + w    delete word before cursor
alt  + d    delete word after cursor
alt  + b    jump to beginning of word
alt  + f    jump to end of word
ctrl + a    jump to beginning of line
ctrl + e    jump to end of line
ctrl + u    delete to beginning of line
ctrl + k    delete to end of line